### PR TITLE
mvn package 打包问题。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/target
+/.idea
+/out
+*.iml
+
+#编译文件
+*.class
+
+#包文件
+*.jar
+*.war
+*.zip
+*.rar
+*.tar.gz

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,15 @@
 	<!-- 项目基本配置 -->
 	<build>
 		<sourceDirectory>src/main/java</sourceDirectory>
-		<testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.png</include>
+                </includes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### 现象：
使用mvn package打包，会发现图片 无法打包进入jar中。另外，在idea中也无法启动（同样的错误，找不到图片）。
![image](https://user-images.githubusercontent.com/9690089/66910897-0e4dd380-f042-11e9-801a-d334c481346e.png)
于是会导致启动的时候，无法显示界面，提示只能使用命令行启动。
原因是默认maven在src/main/java中只编译java文件，其他的文件会被忽略。
### 修复：
1、添加.gitignore文件
2、修复打包错误